### PR TITLE
Include string in action type union

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -99,6 +99,7 @@ export type CustomActionFunction = (
 ) => Promise<string> | string; // Check return type?
 
 export type ActionType =
+	| string
 	| ActionConfig
 	| AddActionConfig
 	| AddManyActionConfig


### PR DESCRIPTION
- String is a legit action type in the js version of plop, but it is not in the ts definition.
- Here is an example: https://github.com/plopjs/plop/blob/master/example/plopfile.js#L74
- This issue was fixed in this PR: https://github.com/plopjs/node-plop/pull/149.
- However, it was lost when the type definition file was moved to `types` directory: https://github.com/plopjs/node-plop/commit/93eaa9d08ce04682ac4433511174445b3dfc9d47
